### PR TITLE
Add shell configuration to bashrc instead of profile

### DIFF
--- a/roles/nvm/tasks/main.yml
+++ b/roles/nvm/tasks/main.yml
@@ -4,9 +4,9 @@
     repo: https://github.com/nvm-sh/nvm.git
     dest: "~/.nvm"
     version: "v{{ nvm_version }}"
-- name: Add config to profile
+- name: Add config to bashrc
   blockinfile:
-    path: ~/.profile
+    path: ~/.bashrc
     marker: "# {mark} ANSIBLE MANAGED NVM CONFIG"
     block: |
       export NVM_DIR="$HOME/.nvm"

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -15,9 +15,9 @@
   git:
     repo: https://github.com/pyenv/pyenv-doctor
     dest: "{{ pyenv_dir }}/plugins/pyenv-doctor"
-- name: "pyenv: Place config in ~/.profile"
+- name: "pyenv: Place config in ~/.bashrc"
   blockinfile:
-    path: ~/.profile
+    path: ~/.bashrc
     marker: "# {mark} ANSIBLE MANAGED PYENV CONFIG"
     block: |
       export PYENV_ROOT="$HOME/.pyenv"


### PR DESCRIPTION
This ensures that it gets sourced by default in the base Ubuntu install
in WSL. ~/.profile seems to mostly be ignored.
