### PR TITLE
Remove spring from default setup file

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -29,8 +29,6 @@
       become: true
     - role: aws
       become: true
-    - role: spring
-      become: true
     - role: utils
       become: true
     # These roles need to run as the user running the


### PR DESCRIPTION
This tool suite is rarely used within the organization at the moment and
currently extracting it seems to be causing issues.
