### PR TITLE
chore(packages)!: remove Java 11

### DIFF
--- a/roles/packages/vars/main.yml
+++ b/roles/packages/vars/main.yml
@@ -1,7 +1,5 @@
 ---
 ubuntu_packages:
-  - openjdk-11-jdk
-  - openjdk-11-doc
   - openjdk-17-jdk
   - openjdk-17-doc
   - maven
@@ -10,4 +8,4 @@ ubuntu_packages:
   - unzip
   - postgresql
   - wslu
-default_java_version: "11"
+default_java_version: "17"


### PR DESCRIPTION
Java 17 is the latest LTS release of Java and is the preferred
environment for developing Java applications. We should no longer
install Java 11 nor should we set it as the default. Note that this
change _will not_ remove Java 11 from existing installs; however, it
will change the default version to Java 17. For new installs, only Java
17 will be installed.
