### PR TITLE
fix: package install fails when run outside Ubuntu

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -3,10 +3,6 @@
   hosts: all
   vars_files:
     - vars/global.yml
-  handlers:
-    - name: Update Desktop Database
-      ansible.builtin.command: "/usr/bin/update-desktop-database"
-      become: true
   pre_tasks:
     - name: "Set facts"
       ansible.builtin.set_fact:

--- a/setup.yml
+++ b/setup.yml
@@ -34,6 +34,11 @@
     # These roles need to run as the root user
     - role: packages
       become: true
+      # Packages are currently only supported for Ubuntu, mostly because the names are
+      # Ubuntu-specific. Not running packages outside Ubuntu will allow for most of the
+      # remainder of the configuration to work without issues (but some tools may still
+      # need to be manually installed)
+      when: ansible_distribution == 'Ubuntu'
     - role: aws
       become: true
     - role: utils


### PR DESCRIPTION
The remainder of this work will be handled in #4, but this gives a
decent start to at least allowing the rest of the configuration to run
outside Ubuntu.
